### PR TITLE
fix spotify search?

### DIFF
--- a/unitunes/services/spotify.py
+++ b/unitunes/services/spotify.py
@@ -245,7 +245,7 @@ class SpotifyService(StreamingService):
         )
 
     def query_generator(self, track: Track) -> List[str]:
-        query = f'track:"{track.name}"'
+        query = f'track:"{track.name.value}"'
         if track.artists:
             query += (
                 f" artist:\"{' '.join([artist.value for artist in track.artists])}\""


### PR DESCRIPTION
I am currently trying to copy a playlist from Youtube Music to Spotify and getting no matches for any track in that playlist, even though I know that they exist on Spotify. I noticed that the Spotify search query always includes a formatted output for the `AliasedString` object such as
`track:"value='Some song' aliases=[]"`
instead of just the track name `'Some Song` (`track.name.value`). Does the Spotify API actually support this pattern? I couldn't find any example of this in the [docs](https://developer.spotify.com/documentation/web-api/reference/#/operations/search). If I try to just pass `track.name.value`, as implemented in this PR, I get at least 2 matches for my playlist.

I also noticed that Spotify seems to be very picky about search queries - if a track has multiple artists listed on Spotify, but we only know one of them from YTM, Spotify cannot find it. So maybe the query generator should also generate a query that omits the artist as a fallback?