### PR TITLE
Change to spotify.py authorization scope to allow lists of playlists to be read

### DIFF
--- a/unitunes/services/spotify.py
+++ b/unitunes/services/spotify.py
@@ -86,7 +86,7 @@ class SpotifyAPIWrapper(SpotifyWrapper):
                 client_id=config["client_id"],
                 client_secret=config["client_secret"],
                 redirect_uri=config["redirect_uri"],
-                scope="user-library-read playlist-modify-private, playlist-modify-public, user-library-modify playlist-read-privateq",
+                scope="user-library-read playlist-modify-private, playlist-modify-public, user-library-modify playlist-read-private",
             )
         )
 

--- a/unitunes/services/spotify.py
+++ b/unitunes/services/spotify.py
@@ -86,7 +86,7 @@ class SpotifyAPIWrapper(SpotifyWrapper):
                 client_id=config["client_id"],
                 client_secret=config["client_secret"],
                 redirect_uri=config["redirect_uri"],
-                scope="user-library-read playlist-modify-private, playlist-modify-public, user-library-modify",
+                scope="user-library-read playlist-modify-private, playlist-modify-public, user-library-modify playlist-read-privateq",
             )
         )
 


### PR DESCRIPTION
Found when I fetched the Spotify playlists, it only added the "Liked Songs" playlist to unitunes. After adding the "playlist-read-private" or "playlist-read-collabrative" scopes, I was able to read my list of Spotify playlists.