### PR TITLE
Fix installation and startup on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ youtube-title-parse = "^1.0.0"
 tqdm = "^4.64.0"
 dearpygui = "^1.6.2"
 appdirs = "^1.4.4"
+platformdirs = "^2.5.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/unitunes/gui/main.py
+++ b/unitunes/gui/main.py
@@ -59,7 +59,7 @@ class GUI:
 
     def load_app_config(self):
         # If the config file doesn't exist, create it
-        config_dir = Path(user_data_dir("unitunes"))
+        config_dir = self.get_config_dir()
         config_dir.mkdir(exist_ok=True)
         config_path = config_dir / "config.json"
         if not config_path.exists():
@@ -75,9 +75,12 @@ class GUI:
             self.save_app_config()
 
     def save_app_config(self):
-        config_path = Path(user_data_dir("unitunes")) / "config.json"
+        config_path = self.get_config_dir() / "config.json"
         with open(config_path, "w") as f:
             f.write(self.app_config.json())
+
+    def get_config_dir(self) -> Path:
+        return Path(user_data_dir("unitunes", False))
 
     def init_themes(self):
         with dpg.theme(tag="hyperlinkTheme"):


### PR DESCRIPTION
- `platformdirs` is a dependency, but was not listed in `pyproject.toml`
- `mkdir` failed for the config directory on Windows as `user_data_dir` returns two levels of directories by default